### PR TITLE
Fixed a few categorization errors, and improved the categories. 

### DIFF
--- a/utility.js
+++ b/utility.js
@@ -156,12 +156,14 @@ function parse_log(log_table) {
             } else if (pass_result == 'catch' || pass_result == 'touchdown' || pass_result == 'dump off') {
               td = $rows.find('td:contains("COMPLETE")');
               if (td.text().includes("AMAZING")) {
-                final_target = td.text().split('by ')[1].split(' ')[0].trim();
+                final_target = td.text().split(' by ')[1].split(' ')[0].trim();
               } else {
-                final_target = td.text().split('to ')[1].split(' ')[0].trim();
+                final_target = td.text().split(' to ')[1].split(' ')[0].trim();
               }
+            } else if (pass_result == 'batted pass') {
+              final_target = td.text().split(',to ')[1].split(' ')[0].trim();
             } else {
-              final_target = td.text().split('to ')[1].split(' ')[0].trim();
+              final_target = td.text().split(' to ')[1].split(' ')[0].trim();
             }
           } else {
             final_target = 'none';
@@ -179,12 +181,14 @@ function parse_log(log_table) {
             } else if (pass_result == 'catch' || pass_result == 'touchdown' || pass_result == 'dump off') {
               td = $rows.find('td:contains("COMPLETE")');
               if (td.text().includes("AMAZING")) {
-                first_target = td.text().split('by ')[1].split(' ')[0].trim();
+                first_target = td.text().split(' by ')[1].split(' ')[0].trim();
               } else {
-                first_target = td.text().split('to ')[1].split(' ')[0].trim();
+                first_target = td.text().split(' to ')[1].split(' ')[0].trim();
               }
+            } else if (pass_result == 'batted pass') {
+              final_target = td.text().split(',to ')[1].split(' ')[0].trim();
             } else {
-              first_target = td.text().split('to ')[1].split(' ')[0].trim();
+              first_target = td.text().split(' to ')[1].split(' ')[0].trim();
             }
             final_target = first_target;
           } else {

--- a/utility.js
+++ b/utility.js
@@ -121,10 +121,11 @@ function parse_log(log_table) {
         play_type = 'pass';
 
         //pass result
-        if ($rows.find('td:contains("scrambles")').length > 0) {
-          pass_result = 'scramble';
-        } else if ($rows.find('td:contains("SACKED")').length > 0) {
+        if ($rows.find('td:contains("SACKED")').length > 0) {
           pass_result = 'sack';
+        } else if ($rows.find('td:contains(" and has decided to run!")').length > 0) {
+          // it should be possible to have a play which is both a sack and a scramble
+          pass_result = 'scramble';
         } else if ($rows.find('td:contains("DROPPED")').length > 0) {
           pass_result = 'drop';
         } else if ($rows.find('td:contains("pass defended")').length > 0) {

--- a/utility.js
+++ b/utility.js
@@ -6,7 +6,7 @@ function parse_log(log_table) {
   $log_data = $(log_table);
 
   $start = $log_data.find('td[colspan="100%"]:eq(0)').parent();
-  $stop_list = $log_data.find('td[bgcolor="#000000"]').parent();
+  $stop_list = $log_data.find('td[bgcolor="#000000"], td[bgcolor="#eeee99"], td:contains("FAILED to convert the 2 Point Conversion")').parent();
 
   //get list of teams playing
   teams = [];

--- a/utility.js
+++ b/utility.js
@@ -46,6 +46,19 @@ function parse_log(log_table) {
       off_formation = off[1].split(',')[0].trim();
       off_play = off[2].trim();
 
+      //reset variable values for new play
+      pass_result = '';
+      first_read = '';
+      first_target = '';
+      final_target = '';
+      scramble_type = '';
+      pass_type = '';
+      pass_yards = '';
+      yac = '';
+      runner = '';
+      hole = '';
+      run_type = '';
+
       //defensive playcall
       def = plays.split('Defensive Package Was :')[1];
       def_pkg = def.split('Coverage :')[0].trim();
@@ -107,16 +120,6 @@ function parse_log(log_table) {
           // In the future, this should be replaced with yardage derived from the change in field position. 
           total_yards = 0;
         }
-
-        //filler variables
-        pass_result = '';
-        first_read = '';
-        first_target = '';
-        final_target = '';
-        scramble_type = '';
-        pass_type = '';
-        pass_yards = '';
-        yac = '';
 
       } else {
         play_type = 'pass';
@@ -264,11 +267,6 @@ function parse_log(log_table) {
           total_yards = 0;
           yac = 0;
         }
-
-        //filler variables
-        runner = '';
-        hole = '';
-        run_type = '';
 
       }
 

--- a/utility.js
+++ b/utility.js
@@ -49,6 +49,7 @@ function parse_log(log_table) {
       //reset variable values for new play
       pass_type = '';
       pass_result = '';
+      pass_direction = '';
       first_read = '';
       first_target = '';
       final_target = '';
@@ -157,6 +158,13 @@ function parse_log(log_table) {
           pass_result = 'miss';
         } else if ($rows.find('td:contains("COMPLETE")').length > 0) {
           pass_result = 'catch';
+        }
+
+        // pass direction
+        if ($rows.find('td:contains(" thrown towards the sideline.")').length > 0) {
+          pass_direction = 'sideline';
+        } else if ($rows.find('td:contains(" thrown towards the middle of the field.")').length > 0) {
+          pass_direction = 'middle';
         }
 
         //1st read status
@@ -289,6 +297,7 @@ function parse_log(log_table) {
         run_type: run_type,
         pass_type: pass_type,
         pass_result: pass_result,
+        pass_direction: pass_direction,
         first_read: first_read,
         first_target: first_target,
         final_target: final_target,

--- a/utility.js
+++ b/utility.js
@@ -157,8 +157,6 @@ function parse_log(log_table) {
           pass_result = 'miss';
         } else if ($rows.find('td:contains("COMPLETE")').length > 0) {
           pass_result = 'catch';
-        } else {
-          pass_result = 'undefined';
         }
 
         //1st read status

--- a/utility.js
+++ b/utility.js
@@ -113,6 +113,7 @@ function parse_log(log_table) {
         first_read = '';
         first_target = '';
         final_target = '';
+        scramble_type = '';
         pass_type = '';
         pass_yards = '';
         yac = '';
@@ -155,6 +156,18 @@ function parse_log(log_table) {
           first_read = 'none';
         } else {
           first_read = 'open';
+        }
+
+        // scrambles
+        scramble_type = '';
+        if (pass_result == 'scramble' || pass_result == "sack") {
+          if ($rows.find('td:contains(" under pressure from the Right side ")').length > 0) {
+            scramble_type = 'pressure right';
+          } else if ($rows.find('td:contains(" under pressure from the Left side ")').length > 0) {
+            scramble_type = 'pressure left';
+          } else if ($rows.find('td:contains(" doesn\'t see anyone open ")').length > 0) {
+            scramble_type = 'coverage';
+          }
         }
 
         //targets
@@ -285,6 +298,7 @@ function parse_log(log_table) {
         first_read: first_read,
         first_target: first_target,
         final_target: final_target,
+        scramble_type: scramble_type,
         pass_type: pass_type,
         target_distance: pass_yards,
         yards_after_catch: yac

--- a/utility.js
+++ b/utility.js
@@ -62,14 +62,20 @@ function parse_log(log_table) {
       def_blitz = (def.split('Blitzing :')[1] ? def.split('Blitzing :')[1].trim().replace(/, /g, '+') : 'none');
 
       //check for run vs pass
-      if ($rows.find('td:contains("Handoff")').length > 0 || $rows.find('td:contains("keeps it")').length > 0) {
+      if ($rows.find('td:contains("Handoff")').length > 0 || $rows.find('td:contains(" handoff ")').length > 0 || $rows.find('td:contains("keeps it")').length > 0) {
         play_type = 'run';
 
         //runner
         if ($rows.find('td:contains("keeps it")').length > 0) {
           runner = 'QB';
-        } else {
+          run_type = 'keeper';
+        } else if ($rows.find('td:contains("Handoff")').length > 0) {
           runner = $rows.find('td:contains("Handoff")').text().split('Handoff to ')[1].split(' ')[0].trim();
+          run_type = 'handoff';
+        } else {
+          // indicates a fumble on the handoff
+          runner = $rows.find('td:contains(" handoff ")').text().split(' to ')[1].split(' ')[0].trim();
+          run_type = 'fumbled handoff';
         }
 
         //hole
@@ -94,7 +100,13 @@ function parse_log(log_table) {
         }
 
         //yards total
-        total_yards = getYards($rows.find('td:contains("ard(s)"):eq(0)').text().match(/(-?\d+\s\d+ Yard)/i)[0].split(' Yard')[0]);
+        if (run_type != "fumbled handoff") {
+          total_yards = getYards($rows.find('td:contains("ard(s)"):eq(0)').text().match(/(-?\d+\s\d+ Yard)/i)[0].split(' Yard')[0]);
+        } else {
+          // this is wrong, unfortunately the actual yardage gained/lost is nontrivial to determine and a filler value will break things
+          // In the future, this should be replaced with yardage derived from the change in field position. 
+          total_yards = 0;
+        }
 
         //filler variables
         pass_result = '';
@@ -242,6 +254,7 @@ function parse_log(log_table) {
         //filler variables
         runner = '';
         hole = '';
+        run_type = '';
 
       }
 
@@ -266,6 +279,7 @@ function parse_log(log_table) {
         total_yards: total_yards,
         runner: runner,
         hole: hole,
+        run_type: run_type,
         pass_result: pass_result,
         first_read: first_read,
         first_target: first_target,


### PR DESCRIPTION
## Changes

- Fixed a bug where "Fausto Mitchel" was mucking up the logic for identifying receiver positions
- Fixed bug (h/t Garrett Foster) which was mixing 2pt conversion attempts in with the subsequent play. 
- Parser now identifies fumbled handoffs as run plays for zero yards. That's not great, but it's better than coding them as passes
- Plays where the QB scrambles and runs out of bounds for a loss are now counted properly
- Reworked the `pass_type` and 'pass_result` columns completely: `pass_type` now covers different groupings of pass plays determine before the pass itself is resolved (scramble, sack, dumpoff, target, etc), while pass_result covers what happened on thrown balls (catch, miss, drop, etc).
- Added a new column `run_type`, with values `keeper`, `handoff`, and `fumbled handoff`
- Added a new column `scramble_type`, with values `coverage`, `pressure left`, and `pressure right`
- Added a new column `is_touchdown`, which says if the play resulted in an offensive touchdown (regardless of run or pass)
- Added new column `pass_direction`, with values `middle` or `sideline` depending on where the QB is reported to be throwing the ball