### PR TITLE
Add special teams

### DIFF
--- a/utility.js
+++ b/utility.js
@@ -707,21 +707,38 @@ function parseLog(log_table,hidden_data,logid) {
 
       dist_decimal = Math.round((dist_yards + dist_inches / 36) * 100) / 100;
 
-      if ($rows.find('td:contains(" was BLOCKED ")').length > 0 || $rows.find('td:contains(" was partially BLOCKED!")').length > 0) {
+      if ($rows.find('td:contains(" was BLOCKED ")').length > 0) {
         kick_result = "blocked";
 
         // get blocked kick returns
+        if ($rows.find('td:contains(" and recovered by the defense.")').length > 0) {
+          if ($rows.find('td:contains("The defensive player falls on the ball.")').length > 0) {
+            return_yards = 0;
+          } else {
+            if ($rows.find('td:contains("The blocked field goal was returned ")').length > 0) {
+              if ($rows.find('td:contains(" for a TOUCHDOWN!")').length > 0) {
+                return_yards = parseInt($rows.find('td:contains("The blocked field goal was returned ")').html().match(/The blocked field goal was returned (\d*) for a TOUCHDOWN!/)[1]);
+                return_result = "touchdown";
+              } else {
+                return_yards = parseInt($rows.find('td:contains("The blocked field goal was returned ")').html().match(/The blocked field goal was returned (\d*) yards\./)[1]);
+              }
+            }
+          }
+        }
+      } else if ($rows.find('td:contains(" was partially BLOCKED!")').length > 0) {  
+        kick_result = "blocked";
       } else if ($rows.find('td:contains(" away is good!")').length == 1) {
         kick_result = "good";
       } else if ($rows.find('td:contains(" away is no good!")').length == 1) {
         kick_result = "no good";
       } else {
-        // this will probably capture partial blocks
         kick_result = "unknown";
       }
 
       fg_match = $rows.find('td:contains(" field goal attempt.")').html().match(/ - (.+?) is coming on for a \D*(\d+)\D*\s\D*(\d+)\D* field goal attempt\./);
       kicker_id = getIdFromSlug(fg_match[1]);
+      // this is the kick ATTEMPT distance. The distance a blocked kick actually travels is not recorded. 
+      // TODO: make better?
       kick_distance = Math.round((parseInt(fg_match[2]) + parseInt(fg_match[3]) / 100) * 100) / 100;
       //console.log(kick_distance + " yard field goal attempt by " + kicker_id + " is " + kick_result);
     }

--- a/utility.js
+++ b/utility.js
@@ -149,7 +149,6 @@ function parseLog(log_table,hidden_data,logid) {
     hole = '';
     run_type = '';
     fumble_recovery_id = '';
-    is_touchdown = 0;
 
     passer_slug = '';
     first_target_slug = '';
@@ -236,7 +235,6 @@ function parseLog(log_table,hidden_data,logid) {
 
       // check for offensive touchdowns
       if ($rows.find('td:contains("Touchdown")').length > 0) {
-        is_touchdown = 1;
         play_result = "offensive touchdown";
       }
 
@@ -536,7 +534,6 @@ function parseLog(log_table,hidden_data,logid) {
         return_yards = Math.round((parseInt(return_match[2]) + parseInt(return_match[3]) / 100) * 100) / 100;
         //console.log(returner_id + " returns for " + return_yards + " yards");
         if ($rows.find('td:contains(" yards for a TOUCHDOWN!")').length == 1) {
-          is_touchdown = 1;
           play_result = "return touchdown";
         }
       } else if ($rows.find('td:contains(" BLOCKED ")').length == 1) {
@@ -607,7 +604,6 @@ function parseLog(log_table,hidden_data,logid) {
         if ($rows.find('td:contains(" yards for a TOUCHDOWN!")').length > 0) {
           return_yards = 100 - kick_landing;
           returned_to = 100;
-          is_touchdown = 1;
           play_result = "return touchdown";
         } else {
           return_id_start = 'KRRY' + qtr + time.split(':')[0] + time.split(':')[1] + '110';
@@ -729,7 +725,6 @@ function parseLog(log_table,hidden_data,logid) {
         pressure_type: pressure_type,
         target_distance: pass_yards,
         yards_after_catch: yac,
-        is_touchdown: is_touchdown,
         exec_time: exec_time,
         kick_team: kick_team,
         rec_team: rec_team,

--- a/utility.js
+++ b/utility.js
@@ -629,7 +629,7 @@ function parseLog(log_table,hidden_data,logid) {
       yard_line = snap[1].split(';')[1].split(')')[0].trim();
       //console.log("Field goal attempt by " + off_team + " against " + def_team + " at Q" + qtr + " " + time);
 
-      if ($rows.find('td:contains(" was BLOCKED ")').length > 0) {
+      if ($rows.find('td:contains(" was BLOCKED ")').length > 0 || $rows.find('td:contains(" was partially BLOCKED!")').length > 0) {
         kick_result = "blocked";
       } else if ($rows.find('td:contains(" away is good!")').length == 1) {
         kick_result = "good";

--- a/utility.js
+++ b/utility.js
@@ -272,6 +272,15 @@ function parseLog(log_table,hidden_data,logid) {
         }
       }
 
+      // check for tackles
+      /*if ($rows.find('td:contains(" before being tackled by ")').length > 0) {
+
+      } else if ($rows.find('td:contains(" before being ridden out of bounds by ")').length > 0) {
+
+      } else if ($rows.find('td:contains(" is eventually ridden out of bounds by ")').length > 0) {
+        
+      }*/
+
       //check for run vs pass
       if ($rows.find('td:contains("Handoff")').length > 0 || $rows.find('td:contains(" handoff ")').length > 0 || $rows.find('td:contains("keeps it")').length > 0) {
         play_type = 'run';

--- a/utility.js
+++ b/utility.js
@@ -84,14 +84,16 @@ function parseLog(log_table,hidden_data,logid) {
   let new_stop = null;
 
   //loop through each section
-  for (i = 0; i < $stop_list.length; i++) {
+  for (i = 1; i < $stop_list.length; i++) {
 
     //get list of elements to read
     $rows = $start.nextUntil($stop_list.eq(i));
 
-    if (i === 0) {
+    if (i === 1) {
       // opening play was a KRTD, so team abbrs are flipped relative to team names. Reverse them.
-      if ($rows.find('td:contains(" yards for a TOUCHDOWN!")').length > 0) {
+      if ($rows.find('td:contains(" yards for a TOUCHDOWN!")').length == 1) {
+        console.log($stop_list.eq(i));
+        console.log($rows);
         let oldAbbr1 = teams[0];
         teams[0] = teams[1];
         teams[1] = oldAbbr1;
@@ -552,7 +554,7 @@ function parseLog(log_table,hidden_data,logid) {
       timeouts_away = kickoff_state.substring(26, 27);
       timeouts_home = kickoff_state.substring(27, 28);
       possession = kickoff_state.substring(30, 31);
-      //console.log("Kickoff by " + def_team + " to " + off_team + ", Q" + qtr + " " + time);
+      console.log("Kickoff by " + def_team + " to " + off_team + ", Q" + qtr + " " + time);
 
       if (kickoff_state.substring(0, 2) == "KT") {
         // touchback

--- a/utility.js
+++ b/utility.js
@@ -160,6 +160,7 @@ function parseLog(log_table,hidden_data,logid) {
     kick_result = '';
     kick_distance = '';
     return_yards = '';
+    return_result = '';
 
     kicker_slug = '';
     returner_slug = '';
@@ -235,7 +236,7 @@ function parseLog(log_table,hidden_data,logid) {
 
       // check for offensive touchdowns
       if ($rows.find('td:contains("Touchdown")').length > 0) {
-        play_result = "offensive touchdown";
+        play_result = "touchdown";
       }
 
       // check for fumbles
@@ -534,7 +535,7 @@ function parseLog(log_table,hidden_data,logid) {
         return_yards = Math.round((parseInt(return_match[2]) + parseInt(return_match[3]) / 100) * 100) / 100;
         //console.log(returner_id + " returns for " + return_yards + " yards");
         if ($rows.find('td:contains(" yards for a TOUCHDOWN!")').length == 1) {
-          play_result = "return touchdown";
+          return_result = "touchdown";
         }
       } else if ($rows.find('td:contains(" BLOCKED ")').length == 1) {
         kick_result = "blocked";
@@ -604,7 +605,7 @@ function parseLog(log_table,hidden_data,logid) {
         if ($rows.find('td:contains(" yards for a TOUCHDOWN!")').length > 0) {
           return_yards = 100 - kick_landing;
           returned_to = 100;
-          play_result = "return touchdown";
+          return_result = "touchdown";
         } else {
           return_id_start = 'KRRY' + qtr + time.split(':')[0] + time.split(':')[1] + '110';
           return_state = $(hidden_data).find('input[value^=' + return_id_start + ']').eq(0).val();
@@ -731,6 +732,7 @@ function parseLog(log_table,hidden_data,logid) {
         kick_result: kick_result,
         kick_distance: kick_distance,
         return_yards: return_yards,
+        return_result: return_result,
         kicker_id: kicker_id,
         returner_id: returner_id
       };

--- a/utility.js
+++ b/utility.js
@@ -521,6 +521,9 @@ function parseLog(log_table,hidden_data,logid) {
         }
       } else if ($rows.find('td:contains(" BLOCKED ")').length == 1) {
         kick_result = "blocked";
+        if ($rows.find('td:contains(" BLOCKED backwards for ")').length == 1) {
+          kick_distance = -1 * kick_distance;
+        }
 
         // TODO: capture blocked kick returns
       } else {

--- a/utility.js
+++ b/utility.js
@@ -565,9 +565,17 @@ function parseLog(log_table,hidden_data,logid) {
           kick_distance = -1 * kick_distance;
         }
 
-        // TODO: capture blocked kick returns
+        if ($rows.find('td:contains("The blocked punt was returned ")').length > 0) {
+          if ($rows.find('td:contains(" for a TOUCHDOWN!")').length > 0) {
+            return_yards = parseInt($rows.find('td:contains("The blocked punt was returned ")').html().match(/The blocked punt was returned (\d*) for a TOUCHDOWN!/)[1]);
+            return_result = "touchdown";
+          } else {
+            return_yards = parseInt($rows.find('td:contains("The blocked punt was returned ")').html().match(/The blocked punt was returned (\d*) yards\./)[1]);
+          }
+        } else if ($rows.find('td:contains("The defensive player falls on the ball.")').length > 0) {
+          return_yards = 0;
+        }
       } else {
-        // this will probably capture partial blocks
         kick_result = "unknown";
       }
     } else if ($rows.find('td:contains("ickoff by ")').length == 1) {
@@ -675,6 +683,8 @@ function parseLog(log_table,hidden_data,logid) {
 
       if ($rows.find('td:contains(" was BLOCKED ")').length > 0 || $rows.find('td:contains(" was partially BLOCKED!")').length > 0) {
         kick_result = "blocked";
+
+        // get blocked kick returns
       } else if ($rows.find('td:contains(" away is good!")').length == 1) {
         kick_result = "good";
       } else if ($rows.find('td:contains(" away is no good!")').length == 1) {

--- a/utility.js
+++ b/utility.js
@@ -541,6 +541,19 @@ function parseLog(log_table,hidden_data,logid) {
       yard_line = snap[1].split(';')[1].split(')')[0].trim();
       //console.log("Punt by " + kick_team + " to " + rec_team + " at Q" + qtr + " " + time);
 
+      //use play identifier to get score and timeout data from hidden data
+      play_id_start = 'PUTL' + qtr + time.split(':')[0] + time.split(':')[1] + down.replaceAll(/\D/g, "");
+      play_state = $(hidden_data).find('input[value^=' + play_id_start + ']').eq(0).val();
+      dist_yards = parseInt(play_state.substring(10, 12));
+      dist_inches = parseInt(play_state.substring(12, 14));
+      points_away = play_state.substring(14, 16);
+      points_home = play_state.substring(16, 18);
+      timeouts_away = play_state.substring(26, 27);
+      timeouts_home = play_state.substring(27, 28);
+      possession = play_state.substring(30, 31);
+
+      dist_decimal = Math.round((dist_yards + dist_inches / 36) * 100) / 100;
+
       punt_match = $rows.find('td:contains("Punt by ")').html().match(/Punt by (.+?) for \D*(\d+)\D*\s\D*(\d+)\D* yards(.*)/);
       kicker_id = getIdFromSlug(punt_match[1]);
       kick_distance = Math.round((parseInt(punt_match[2]) + parseInt(punt_match[3]) / 100) * 100) / 100;
@@ -680,6 +693,19 @@ function parseLog(log_table,hidden_data,logid) {
       dist = snap[1].split('(')[1].split(';')[0].split('and')[1].trim();
       yard_line = snap[1].split(';')[1].split(')')[0].trim();
       //console.log("Field goal attempt by " + off_team + " against " + def_team + " at Q" + qtr + " " + time);
+
+      //use play identifier to get score and timeout data from hidden data
+      play_id_start = 'FGOA' + qtr + time.split(':')[0] + time.split(':')[1] + down.replaceAll(/\D/g, "");
+      play_state = $(hidden_data).find('input[value^=' + play_id_start + ']').eq(0).val();
+      dist_yards = parseInt(play_state.substring(10, 12));
+      dist_inches = parseInt(play_state.substring(12, 14));
+      points_away = play_state.substring(14, 16);
+      points_home = play_state.substring(16, 18);
+      timeouts_away = play_state.substring(26, 27);
+      timeouts_home = play_state.substring(27, 28);
+      possession = play_state.substring(30, 31);
+
+      dist_decimal = Math.round((dist_yards + dist_inches / 36) * 100) / 100;
 
       if ($rows.find('td:contains(" was BLOCKED ")').length > 0 || $rows.find('td:contains(" was partially BLOCKED!")').length > 0) {
         kick_result = "blocked";

--- a/utility.js
+++ b/utility.js
@@ -89,7 +89,6 @@ function parseLog(log_table,hidden_data,logid) {
 
     if (i === 0) {
       // opening play was a KRTD, so team abbrs are flipped relative to team names. Reverse them.
-      console.log($rows);
       if ($rows.find('td:contains(" yards for a TOUCHDOWN!")').length > 0) {
         let oldAbbr1 = teams[0];
         teams[0] = teams[1];
@@ -152,6 +151,8 @@ function parseLog(log_table,hidden_data,logid) {
     kick_result = '';
     kick_distance = '';
     return_yards = '';
+
+    exec_time = '';
 
     //check for valid non-special teams play
     if ($rows.find('td:contains("- The ball is snapped to")').length == 1) {
@@ -516,7 +517,7 @@ function parseLog(log_table,hidden_data,logid) {
         // touchback
         play_type = "kickoff";
         kick_result = "touchback";
-        console.log("Kickoff into the end zone, touchback");
+        //console.log("Kickoff into the end zone, touchback");
       } else {
         if (kickoff_state.substring(0, 4) == "KRNW") {
           // kickoff returned
@@ -557,6 +558,10 @@ function parseLog(log_table,hidden_data,logid) {
 
     // if this part was actually a play, write the data
     if (is_play) {
+      if ($rows.find('td:contains(" seconds to execute.")').length == 1) {
+        exec_time = parseInt($rows.find('td:contains(" seconds to execute.")').html().match(/The play required (\d*) seconds to execute\./)[1]);
+      }
+
       var play = {
         league: league,
         year: year,
@@ -606,6 +611,7 @@ function parseLog(log_table,hidden_data,logid) {
         target_distance: pass_yards,
         yards_after_catch: yac,
         is_touchdown: is_touchdown,
+        exec_time: exec_time,
         kick_result: kick_result,
         kick_distance: kick_distance,
         return_yards: return_yards

--- a/utility.js
+++ b/utility.js
@@ -511,8 +511,10 @@ function parseLog(log_table,hidden_data,logid) {
         return_match = $rows.find('td:contains("The punt is returned by ")').html().match(/The punt is returned by (.+?) \D*(\d+)\D*\s\D*(\d+)\D* yards/);
         returner_id = getIdFromSlug(return_match[1]);
         return_yards = Math.round((parseInt(return_match[2]) + parseInt(return_match[3]) / 100) * 100) / 100;
-        // TODO: check for touchdowns
         //console.log(returner_id + " returns for " + return_yards + " yards");
+        if ($rows.find('td:contains(" yards for a TOUCHDOWN!")').length == 1) {
+          is_touchdown = 1;
+        }
       } else if ($rows.find('td:contains(" BLOCKED ")')) {
         kick_result = "blocked";
         //console.log("Blocked");

--- a/utility.js
+++ b/utility.js
@@ -152,6 +152,11 @@ function parseLog(log_table,hidden_data,logid) {
     kick_distance = '';
     return_yards = '';
 
+    kicker_slug = '';
+    returner_slug = '';
+    kicker_id = '';
+    returner_id = '';
+
     exec_time = '';
 
     //check for valid non-special teams play
@@ -491,8 +496,10 @@ function parseLog(log_table,hidden_data,logid) {
     } else if ($rows.find('td:contains("ickoff by ")').length == 1) {
       is_play = true;
 
+      kickoff_msg = $rows.find('td:contains("ickoff by ")').html();
+
       // off_team = return team, def_team = kicking team
-      kicking_name = $rows.find('td:contains("ickoff by ")').html().match(/ of the <b>(.*)<\/b>\./)[1];
+      kicking_name = kickoff_msg.match(/ of the <b>(.*)<\/b>\./)[1];
       if (kicking_name == name1) {
         off_team = teams[1];
         def_team = teams[0];
@@ -502,6 +509,9 @@ function parseLog(log_table,hidden_data,logid) {
       } else {
         console.log("Unrecognized kicking team name: '" + kicking_name + "'");
       }
+
+      kicker_slug = kickoff_msg.match(/ickoff by (.*?) of the <b>/)[1];
+      kicker_id = getIdFromSlug(kicker_slug);
 
       kickoff_state = $kickoff_list.eq(kickoff_ptr).val();
       qtr = kickoff_state.substring(4, 5);
@@ -547,6 +557,9 @@ function parseLog(log_table,hidden_data,logid) {
           returned_to = Math.round((returned_to_yards + returned_to_inches / 36) * 100) / 100;
           return_yards = Math.round((returned_to - kick_landing) * 100) / 100;
         }
+
+        returner_slug = $rows.find('td:contains("The ball is returned by ")').html().match(/The ball is returned by (.*?) <span class="supza">/)[1];
+        returner_id = getIdFromSlug(returner_slug);
 
         //console.log("kickoff of " + kick_distance + " yards to the " + kick_landing + " yardline, returned " + return_yards + " yards to the " + returned_to);
       }
@@ -614,7 +627,9 @@ function parseLog(log_table,hidden_data,logid) {
         exec_time: exec_time,
         kick_result: kick_result,
         kick_distance: kick_distance,
-        return_yards: return_yards
+        return_yards: return_yards,
+        kicker_id: kicker_id,
+        returner_id: returner_id
       };
       game_log.push(play);
     }

--- a/utility.js
+++ b/utility.js
@@ -493,6 +493,20 @@ function parseLog(log_table,hidden_data,logid) {
       dist = snap[1].split('(')[1].split(';')[0].split('and')[1].trim();
       yard_line = snap[1].split(';')[1].split(')')[0].trim();
       //console.log("Punt by " + def_team + " to " + off_team + " at Q" + qtr + " " + time);
+
+      punt_match = $rows.find('td:contains("Punt by ")').html().match(/Punt by (.+?) for \D*(\d+)\D*\s\D*(\d+)\D* yards(.*)/);
+      kicker_id = getIdFromSlug(punt_match[1]);
+      kick_distance = Math.round((parseInt(punt_match[2]) + parseInt(punt_match[3]) / 100) * 100) / 100;
+
+      if (punt_match[4] === "; touchback.") {
+        kick_result = "touchback";
+      } else if (punt_match[4] === "; no return.") {
+        kick_result = "no return";
+      } else if (punt_match[4] === ".. looks to be returnable.") {
+        return_match = $rows.find('td:contains("The punt is returned by ")').html().match(/The punt is returned by (.+?) \D*(\d+)\D*\s\D*(\d+)\D* yards/);
+        returner_id = getIdFromSlug(return_match[1]);
+        return_yards = Math.round((parseInt(return_match[2]) + parseInt(return_match[3]) / 100) * 100) / 100;
+      }
     } else if ($rows.find('td:contains("ickoff by ")').length == 1) {
       is_play = true;
 

--- a/utility.js
+++ b/utility.js
@@ -504,11 +504,10 @@ function parseLog(log_table,hidden_data,logid) {
 
       if (punt_match[4] === "; touchback.") {
         kick_result = "touchback";
-        //console.log("Touchback");
       } else if (punt_match[4] === "; no return.") {
         kick_result = "no return";
-        //console.log("No return");
-      } else if (punt_match[4] === ".. looks to be returnable.") {
+      } else if (punt_match[4] === ".. looks to be returnable." || punt_match[4] === ".. not the best decision to return this by the return man...") {
+        kick_result = "return";
         return_match = $rows.find('td:contains("The punt is returned by ")').html().match(/The punt is returned by (.+?) \D*(\d+)\D*\s\D*(\d+)\D* yards/);
         returner_id = getIdFromSlug(return_match[1]);
         return_yards = Math.round((parseInt(return_match[2]) + parseInt(return_match[3]) / 100) * 100) / 100;
@@ -516,9 +515,8 @@ function parseLog(log_table,hidden_data,logid) {
         if ($rows.find('td:contains(" yards for a TOUCHDOWN!")').length == 1) {
           is_touchdown = 1;
         }
-      } else if ($rows.find('td:contains(" BLOCKED ")')) {
+      } else if ($rows.find('td:contains(" BLOCKED ")').length == 1) {
         kick_result = "blocked";
-        //console.log("Blocked");
 
         // TODO: capture blocked kick returns
       } else {

--- a/utility.js
+++ b/utility.js
@@ -7,11 +7,12 @@ function parseLog(log_table,hidden_data,logid) {
 
   $start = $log_data.find('td[colspan="100%"]:eq(0)').parent();
   $stop_list = $log_data.find(
-    'td[bgcolor="#000000"], td[bgcolor="#eeee99"], td:contains("FAILED to convert the 2 Point Conversion"), td[bgcolor="#eeffee"]:contains("Offensive Players :"), td[bgcolor="#eeeeff"]:contains("Offensive Players :")'
+    'td[bgcolor="#000000"], td[bgcolor="#eeee99"], td[bgcolor="#eeffee"]:contains("FAILED to convert the 2 Point Conversion"), td[bgcolor="#eeeeff"]:contains("FAILED to convert the 2 Point Conversion"), td[bgcolor="#eeffee"]:contains("Offensive Players :"), td[bgcolor="#eeeeff"]:contains("Offensive Players :")'
     ).parent();
 
   // get an ordered listing of all kickoff plays, to make lookups possible
   $kickoff_list = $(hidden_data).find('input[value^=KRNW], input[value^=KT], input[value^=KRSQ], input[value^=FK]');
+  //console.log($kickoff_list);
   kickoff_ptr = 0;
 
   // parse logid to get league, year, week
@@ -84,20 +85,18 @@ function parseLog(log_table,hidden_data,logid) {
   let new_stop = null;
 
   //loop through each section
-  for (i = 1; i < $stop_list.length; i++) {
+  for (i = 0; i < $stop_list.length; i++) {
 
     //get list of elements to read
     $rows = $start.nextUntil($stop_list.eq(i));
 
-    if (i === 1) {
+    if (i === 0) {
       // opening play was a KRTD, so team abbrs are flipped relative to team names. Reverse them.
       if ($rows.find('td:contains(" yards for a TOUCHDOWN!")').length == 1) {
-        console.log($stop_list.eq(i));
-        console.log($rows);
         let oldAbbr1 = teams[0];
         teams[0] = teams[1];
         teams[1] = oldAbbr1;
-        console.log(name1 + " = " + teams[0] + ", " + name2 + " = " + teams[1]);
+        //console.log(name1 + " = " + teams[0] + ", " + name2 + " = " + teams[1]);
       }
     }
 
@@ -546,7 +545,9 @@ function parseLog(log_table,hidden_data,logid) {
       kicker_slug = kickoff_msg.match(/ickoff by (.*?) of the <b>/)[1];
       kicker_id = getIdFromSlug(kicker_slug);
 
+      //console.log("kickoff_ptr = " + kickoff_ptr);
       kickoff_state = $kickoff_list.eq(kickoff_ptr).val();
+      //console.log(kickoff_state);
       qtr = kickoff_state.substring(4, 5);
       time = kickoff_state.substring(5, 7) + ":" + kickoff_state.substring(7, 9);
       points_away = kickoff_state.substring(14, 16);
@@ -554,7 +555,7 @@ function parseLog(log_table,hidden_data,logid) {
       timeouts_away = kickoff_state.substring(26, 27);
       timeouts_home = kickoff_state.substring(27, 28);
       possession = kickoff_state.substring(30, 31);
-      console.log("Kickoff by " + def_team + " to " + off_team + ", Q" + qtr + " " + time);
+      //console.log("Kickoff by " + def_team + " to " + off_team + ", Q" + qtr + " " + time);
 
       if (kickoff_state.substring(0, 2) == "KT") {
         // touchback
@@ -592,14 +593,15 @@ function parseLog(log_table,hidden_data,logid) {
           return_yards = Math.round((returned_to - kick_landing) * 100) / 100;
         }
 
+        //console.log("kickoff of " + kick_distance + " yards to the " + kick_landing + " yardline, returned " + return_yards + " yards to the " + returned_to);
+
         returner_slug = $rows.find('td:contains("The ball is returned by ")').html().match(/The ball is returned by (.*?) <span class="supza">/)[1];
         returner_id = getIdFromSlug(returner_slug);
-
-        //console.log("kickoff of " + kick_distance + " yards to the " + kick_landing + " yardline, returned " + return_yards + " yards to the " + returned_to);
       }
       
       // safe assumption, no penalties in DR affect kickoffs
       yard_line = "Own 35";
+      //console.log("kickoff_ptr = " + kickoff_ptr + ", incrementing...");
       kickoff_ptr++;
     } else if ($rows.find('td:contains(" field goal attempt.")').length > 0) {
       is_play = true;

--- a/utility.js
+++ b/utility.js
@@ -101,6 +101,11 @@ function parseLog(log_table,hidden_data,logid) {
     }
 
     //reset variable values for new play
+    off_team = '';
+    def_team = '';
+    kick_team = '';
+    rec_team = '';
+
     qtr = '';
     time = '';
     down = '';
@@ -483,19 +488,18 @@ function parseLog(log_table,hidden_data,logid) {
       //get scenario
       snap = $rows.find('td:contains(" is lined up to punt; ")').text().split(' - ');
 
-      // off_team = return team, def_team = kicking team
-      def_team = snap[0].trim();
-      if (def_team == teams[0]) {
-        off_team = teams[1];
+      kick_team = snap[0].trim();
+      if (kick_team == teams[0]) {
+        rec_team = teams[1];
       } else {
-        off_team = teams[0];
+        rec_team = teams[0];
       }
       qtr = snap[1].split(' ')[0].split('Q')[1].trim();
       time = snap[1].split(' ')[1].trim();
       down = snap[1].split('(')[1].split('and')[0].trim();
       dist = snap[1].split('(')[1].split(';')[0].split('and')[1].trim();
       yard_line = snap[1].split(';')[1].split(')')[0].trim();
-      //console.log("Punt by " + def_team + " to " + off_team + " at Q" + qtr + " " + time);
+      //console.log("Punt by " + kick_team + " to " + rec_team + " at Q" + qtr + " " + time);
 
       punt_match = $rows.find('td:contains("Punt by ")').html().match(/Punt by (.+?) for \D*(\d+)\D*\s\D*(\d+)\D* yards(.*)/);
       kicker_id = getIdFromSlug(punt_match[1]);
@@ -528,14 +532,13 @@ function parseLog(log_table,hidden_data,logid) {
 
       kickoff_msg = $rows.find('td:contains("ickoff by ")').html();
 
-      // off_team = return team, def_team = kicking team
       kicking_name = kickoff_msg.match(/ of the <b>(.*)<\/b>\./)[1];
       if (kicking_name == name1) {
-        off_team = teams[1];
-        def_team = teams[0];
+        rec_team = teams[1];
+        kick_team = teams[0];
       } else if (kicking_name == name2) {
-        off_team = teams[0];
-        def_team = teams[1];
+        rec_team = teams[0];
+        kick_team = teams[1];
       } else {
         console.log("Unrecognized kicking team name: '" + kicking_name + "'");
       }
@@ -700,6 +703,8 @@ function parseLog(log_table,hidden_data,logid) {
         yards_after_catch: yac,
         is_touchdown: is_touchdown,
         exec_time: exec_time,
+        kick_team: kick_team,
+        rec_team: rec_team,
         kick_result: kick_result,
         kick_distance: kick_distance,
         return_yards: return_yards,

--- a/utility.js
+++ b/utility.js
@@ -140,7 +140,8 @@ function parseLog(log_table,hidden_data,logid) {
     //double_defender = '';
     //area_defender = '';
     //tackler = '';
-    //pass_deflector = '';
+    pass_disruptor = '';
+    pass_disruptor_id = '';
     pressure_type = '';
     pass_yards = '';
     yac = '';
@@ -155,6 +156,7 @@ function parseLog(log_table,hidden_data,logid) {
     final_target_slug = '';
     first_defender_slug = '';
     final_defender_slug = '';
+    pass_disruptor_slug = '';
     runner_slug = '';
 
     kick_result = '';
@@ -239,7 +241,7 @@ function parseLog(log_table,hidden_data,logid) {
         play_result = "touchdown";
       }
 
-      // check for fumbles FUMBLE! Recovered by 
+      // check for fumbles 
       if ($rows.find('td:contains("FUMBLE!  Recovered by")').length > 0) {
         fumble_match = $rows.find('td:contains("FUMBLE!  Recovered by ")').html().match(/FUMBLE!  Recovered by (.*) of <b>(.*)<\/b>!/);
         fumble_recovery_id = getIdFromSlug(fumble_match[1]);
@@ -342,10 +344,13 @@ function parseLog(log_table,hidden_data,logid) {
           pass_result = 'drop';
         } else if ($rows.find('td:contains("pass defended")').length > 0) {
           pass_result = 'pass defended';
+          pass_disruptor_slug = $rows.find('td:contains("pass defended")').html().match(/, INCOMPLETE\.\. credit (.*) with a pass defended\./)[1];
         } else if ($rows.find('td:contains("batted down")').length > 0) {
           pass_result = 'batted pass';
+          pass_disruptor_slug = $rows.find('td:contains("batted down")').html().match(/\.\.\. batted down by (.*)\.\.\. incomplete\./)[1];
         } else if ($rows.find('td:contains("INTERCEPTED")').length > 0) {
           pass_result = 'intercepted';
+          pass_disruptor_slug = $rows.find('td:contains("INTERCEPTED")').html().match(/yard\(s\) downfield, INTERCEPTED by (.*)!/)[1];
         } else if ($rows.find('td:contains("INCOMPLETE")').length > 0) {
           pass_result = 'miss';
         } else if ($rows.find('td:contains("COMPLETE")').length > 0) {
@@ -479,6 +484,8 @@ function parseLog(log_table,hidden_data,logid) {
         final_target_id = getIdFromSlug(final_target_slug);
         final_defender = getPositionFromSlug(final_defender_slug);
         final_defender_id = getIdFromSlug(final_defender_slug);
+        pass_disruptor = getPositionFromSlug(pass_disruptor_slug);
+        pass_disruptor_id = getIdFromSlug(pass_disruptor_slug);
 
         //yardage
         td = $rows.find('td:contains("ard(s)")');
@@ -738,6 +745,8 @@ function parseLog(log_table,hidden_data,logid) {
         first_defender_id: first_defender_id,
         final_defender: final_defender,
         final_defender_id: final_defender_id,
+        pass_disruptor: pass_disruptor,
+        pass_disruptor_id: pass_disruptor_id,
         fumble_recovery_id: fumble_recovery_id,
         pressure_type: pressure_type,
         target_distance: pass_yards,

--- a/utility.js
+++ b/utility.js
@@ -551,7 +551,7 @@ function parseLog(log_table,hidden_data,logid) {
       }
       
       // safe assumption, no penalties in DR affect kickoffs
-      yard_line = "own 35";
+      yard_line = "Own 35";
       kickoff_ptr++;
     }
 
@@ -606,7 +606,9 @@ function parseLog(log_table,hidden_data,logid) {
         target_distance: pass_yards,
         yards_after_catch: yac,
         is_touchdown: is_touchdown,
-        kick_result: kick_result
+        kick_result: kick_result,
+        kick_distance: kick_distance,
+        return_yards: return_yards
       };
       game_log.push(play);
     }

--- a/utility.js
+++ b/utility.js
@@ -239,9 +239,9 @@ function parseLog(log_table,hidden_data,logid) {
         play_result = "touchdown";
       }
 
-      // check for fumbles
-      if ($rows.find('td:contains("FUMBLE! Recovered by ")').length > 0) {
-        fumble_match = $rows.find('td:contains("FUMBLE! Recovered by ")').html().match(/FUMBLE! Recovered by (.*) of <b>(.*)<\/b>!/);
+      // check for fumbles FUMBLE! Recovered by 
+      if ($rows.find('td:contains("FUMBLE!  Recovered by")').length > 0) {
+        fumble_match = $rows.find('td:contains("FUMBLE!  Recovered by ")').html().match(/FUMBLE!  Recovered by (.*) of <b>(.*)<\/b>!/);
         fumble_recovery_id = getIdFromSlug(fumble_match[1]);
         fumble_recovery_team_name = fumble_match[2];
         let recovery_team_num = 1;
@@ -252,6 +252,21 @@ function parseLog(log_table,hidden_data,logid) {
           play_result = "fumble recovered";
         } else {
           play_result = "fumble lost";
+
+          // "look ahead" to see fumble return results
+          $next_rows = $stop_list.eq(i).nextUntil($stop_list.eq(i+1));
+          if ($next_rows.find('td:contains("The fumble recovery and return time took ")').length > 0) {
+            if ($next_rows.find('td:contains("The defensive player falls on the ball.")').length > 0) {
+              return_yards = 0;
+            } else if ($next_rows.find('td:contains("The fumble was returned ")').length > 0) {
+              if ($next_rows.find('td:contains(" for a TOUCHDOWN!")').length > 0) {
+                return_yards = parseInt($next_rows.find('td:contains("The fumble was returned ")').html().match(/The fumble was returned (\d*) for a TOUCHDOWN!/)[1]);
+                return_result = "touchdown";
+              } else {
+                return_yards = parseInt($next_rows.find('td:contains("The fumble was returned ")').html().match(/The fumble was returned (\d*) yards\./)[1]);
+              }
+            }
+          }
         }
       }
 
@@ -723,6 +738,7 @@ function parseLog(log_table,hidden_data,logid) {
         first_defender_id: first_defender_id,
         final_defender: final_defender,
         final_defender_id: final_defender_id,
+        fumble_recovery_id: fumble_recovery_id,
         pressure_type: pressure_type,
         target_distance: pass_yards,
         yards_after_catch: yac,

--- a/utility.js
+++ b/utility.js
@@ -497,15 +497,26 @@ function parseLog(log_table,hidden_data,logid) {
       punt_match = $rows.find('td:contains("Punt by ")').html().match(/Punt by (.+?) for \D*(\d+)\D*\s\D*(\d+)\D* yards(.*)/);
       kicker_id = getIdFromSlug(punt_match[1]);
       kick_distance = Math.round((parseInt(punt_match[2]) + parseInt(punt_match[3]) / 100) * 100) / 100;
+      //console.log("Punter " + kicker_id + " punted " + kick_distance + " yards");
 
       if (punt_match[4] === "; touchback.") {
         kick_result = "touchback";
+        //console.log("Touchback");
       } else if (punt_match[4] === "; no return.") {
         kick_result = "no return";
+        //console.log("No return");
       } else if (punt_match[4] === ".. looks to be returnable.") {
         return_match = $rows.find('td:contains("The punt is returned by ")').html().match(/The punt is returned by (.+?) \D*(\d+)\D*\s\D*(\d+)\D* yards/);
         returner_id = getIdFromSlug(return_match[1]);
         return_yards = Math.round((parseInt(return_match[2]) + parseInt(return_match[3]) / 100) * 100) / 100;
+        //console.log(returner_id + " returns for " + return_yards + " yards");
+      } else if ($rows.find('td:contains(" BLOCKED ")')) {
+        kick_result = "blocked";
+        //console.log("Blocked");
+
+        // TODO: capture blocked kick returns
+      } else {
+        kick_result = "unknown";
       }
     } else if ($rows.find('td:contains("ickoff by ")').length == 1) {
       is_play = true;

--- a/utility.js
+++ b/utility.js
@@ -351,6 +351,24 @@ function parseLog(log_table,hidden_data,logid) {
         } else if ($rows.find('td:contains("INTERCEPTED")').length > 0) {
           pass_result = 'intercepted';
           pass_disruptor_slug = $rows.find('td:contains("INTERCEPTED")').html().match(/yard\(s\) downfield, INTERCEPTED by (.*)!/)[1];
+
+          // "look ahead" to see interception return results
+          $next_rows = $stop_list.eq(i).nextUntil($stop_list.eq(i+1));
+          if ($next_rows.find('td:contains("The interception return time took ")').length > 0) {
+            if ($next_rows.find('td:contains("The defensive player is stopped immediately\.")').length > 0) {
+              return_yards = 0;
+              if ($next_rows.find('td:contains("The interception took place in the endzone\.")').length > 0) {
+                return_result = "touchback";
+              }
+            } else if ($next_rows.find('td:contains("The interception was returned ")').length > 0) {
+              if ($next_rows.find('td:contains(" for a TOUCHDOWN!")').length > 0) {
+                return_yards = parseInt($next_rows.find('td:contains("The interception was returned ")').html().match(/The interception was returned (\d*) for a TOUCHDOWN!/)[1]);
+                return_result = "touchdown";
+              } else {
+                return_yards = parseInt($next_rows.find('td:contains("The interception was returned ")').html().match(/The interception was returned (\d*) yards\./)[1]);
+              }
+            }
+          }
         } else if ($rows.find('td:contains("INCOMPLETE")').length > 0) {
           pass_result = 'miss';
         } else if ($rows.find('td:contains("COMPLETE")').length > 0) {


### PR DESCRIPTION
Somewhat exceeded my mandate here. Primary additions:

- Core special teams plays are recorded: kickoffs, punts, field goals. No PATs (yet?)
- Now tracking fumbles, including who recovered them
- Now tracking interception and fumble returns
- Now tracking penalties
- Replaced `is_touchdown` with a more broadly applicable `play_result` column
- Now tracking execution time of plays (although turnover return time is left out)
- Fixed some minor bugs